### PR TITLE
LinkedIn and GitHub link values are hardcoded always rendered as [mikhail-liamets]

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -4,9 +4,13 @@ contacts:
   email: john.doe@email.com 
   phone: "+123 456 7890"
   address: "123 Imaginary Street, Imaginary City, Imaginary Country"
-  linkedin: "https://www.linkedin.com/in/mikhail-liamets/"
   nationality: Imaginarian
-  github: "https://github.com/caffeinatedgaze/"
+  linkedin:
+    url: https://www.linkedin.com/in/mikhail-liamets/
+    displayText: mikhail-liamets
+  github:
+    url: https://github.com/caffeinatedgaze/
+    displayText: caffeinatedgaze
 
 skills:
   - name: Programming Languages

--- a/main.typ
+++ b/main.typ
@@ -22,8 +22,8 @@
       
       Email: #link("mailto:" + configuration.contacts.email) \
       Phone: #link("tel:" + configuration.contacts.phone) \
-      LinkedIn: #link(configuration.contacts.linkedin)[mikhail-liamets] \
-      GitHub: #link(configuration.contacts.github)[caffeintazedgaze] \
+      LinkedIn: #link(configuration.contacts.linkedin.url)[#configuration.contacts.linkedin.displayText] \
+      GitHub: #link(configuration.contacts.github.url)[#configuration.contacts.github.displayText] \
       
       #configuration.contacts.address
     ]


### PR DESCRIPTION
As in https://github.com/caffeinatedgaze/bare-bones-cv/issues/1 discussed the displayText values for linkedin and github are hardcoded.

I just ran into the same issue and fixed it using the changes in this pr.